### PR TITLE
Pirouette effect table

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,13 +24,20 @@
     <div class="datablock">
       <p>Turn: <span id="turn-num">[LOADING]</span></p>
       <p>Phase: <span id="phase-num">[LOADING]</span></p>
-      <p>
-        Pirouette effect: <span id="piro-effect">[LOADING]</span>
-        <span hidden class="highlightpreview" id="piro-preview-info">
-          <br />&nbsp;&nbsp;
-          This effect will be applied upon executing this previewed turn.
-        </span>
-      </p>
+      <div class="piro-outer-container">
+        <p>Pirouette effect:</p>
+        <div class="pirouette-table" id="pirouette-table">
+          <li>No combat effect (random SFX)</li>
+          <li>Lowers Jevil's Defense by 4</li>
+          <li>60% less invincibility for the turn</li>
+          <li>Lowers Jevil's Attack by 30% for the turn</li>
+          <li>No combat effect (bird flies)</li>
+          <li>25-55 HP heal to a random party member</li>
+          <li>Party's HP bars are shuffled</li>
+          <li>Increases Jevil's Attack by 25% for the turn</li>
+          <li>36-50 HP heal to all party members</li>
+        </div>
+      </div>
     </div>
 
     <div class="datablock">

--- a/script.js
+++ b/script.js
@@ -94,31 +94,17 @@ function pirouetteCycleStep() {
 }
 
 function updatePirouette() {
-    const effectTable = [
-        [false, "No combat effect (random SFX)"],
-        [false, "Lowers Jevil's Defense by 4"],
-        [true, "60% less invincibility for the turn"],
-        [false, "Lowers Jevil's Attack by 30% for the turn"],
-        [false, "No combat effect (bird flies)"],
-        [false, "25-55 HP heal to a random party member"],
-        [true, "Party's HP bars are shuffled"],
-        [true, "Increases Jevil's Attack by 25% for the turn"],
-        [false, "36-50 HP heal to all party members"],
-    ];
-    const [isNegative, effectDescription] = effectTable[pirouetteCycleCounter];
-    const el = document.getElementById("piro-effect");
-    el.textContent = effectDescription;
-    if (isNegative) {
-        el.className = "highlightnegative";
-    } else {
-        el.className = "highlightpositive";
-    }
+    const effectTable = [false, false, true, false, false, false, true, true, false];
+    const container = document.getElementById("pirouette-table");
+    const selectedEntry = container.children[pirouetteCycleCounter];
+    const highlightClass = effectTable[pirouetteCycleCounter]
+        ? "highlightnegative" : "highlightpositive";
+    selectedEntry.className = `selected ${highlightClass}`;
 }
 
 function actionClickImpl(name, tired) {
     loadPreviewState();
 
-    document.getElementById("piro-preview-info").hidden = true;
     document.getElementById("preview-header").hidden = false;
     document.getElementById("action-submit").disabled = false;
     document.getElementById("preview-action").textContent = name;
@@ -152,7 +138,6 @@ function hidePreviewIndicators() {
     document.getElementById("action-submit").disabled = true;
 
     document.getElementById("preview-header").hidden = true;
-    document.getElementById("piro-preview-info").hidden = true;
 }
 
 //---------------------//
@@ -162,7 +147,6 @@ function hidePreviewIndicators() {
 function onLoad() {
     document.getElementById("pirouette").addEventListener("click", () => {
         actionClickImpl("Pirouette", 0.5);
-        document.getElementById("piro-preview-info").hidden = false;
     });
     document.getElementById("hypnosis").addEventListener("click", () => {
         actionClickImpl("Hypnosis", 1);
@@ -181,6 +165,10 @@ function onLoad() {
 
         hidePreviewIndicators();
 
+        const entries = document.getElementById("pirouette-table");
+        for (const el of entries.children) {
+            el.className = "";
+        }
         pirouetteCycleStep();
         updateVisibleState();
     });

--- a/style.css
+++ b/style.css
@@ -31,6 +31,33 @@ h2 {
     margin: 8px 0;
 }
 
+.piro-outer-container {
+    margin-top: 10px;
+    margin-left: 20px;
+}
+
+.piro-outer-container p {
+    margin: 0;
+    margin-bottom: 2px;
+}
+
+.pirouette-table {
+    width: max-content;
+    border: 2px solid darkgray;
+    padding: 8px;
+    padding-left: 25px;
+}
+
+.pirouette-table li {
+    margin-top: 1px;
+    margin-bottom: 1px;
+    list-style-type: none;
+}
+
+.pirouette-table li.selected {
+    list-style-type: "✦ ";
+}
+
 .highlightnegative {
     color: red;
 }


### PR DESCRIPTION
Adds a table of the pirouette effect cycle, highlighting the current one.

This replaces the old pirouette display system, which *only* showed the current effect. This was undesirable because in-battle planning often wants to know what future pirouettes will be.